### PR TITLE
Add namespace to the configmap's metadata

### DIFF
--- a/deploy/olm-catalog/configmap.yml
+++ b/deploy/olm-catalog/configmap.yml
@@ -2,6 +2,7 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: ember-csi-operator
+  namespace: openshift-operator-lifecycle-manager
 data:
   customResourceDefinitions: |-
     - apiVersion: apiextensions.k8s.io/v1beta1
@@ -57,7 +58,7 @@ data:
         labels:
           olm-owner-enterprise-app: ember-csi-operator
           olm-status-descriptors: embercsi.v0.0.2
-      
+
         install:
           strategy: deployment
           spec:
@@ -165,9 +166,9 @@ data:
                 resources:
                 - persistentvolumeclaims
                 verbs:
-                - get 
-                - list 
-                - watch 
+                - get
+                - list
+                - watch
                 - update
               - apiGroups:
                 - storage.k8s.io
@@ -224,11 +225,11 @@ data:
                     serviceAccount: ember-csi-operator
         customresourcedefinitions:
           owned:
-            - description: Represents an instance of a EmberCSI application
-              displayName: EmberCSI Application
-              kind: EmberCSI
-              name: embercsis.ember-csi.io
-              version: v1alpha1
+          - name: embercsis.ember-csi.io
+            version: v1alpha1
+            kind: EmberCSI
+            displayName: EmberCSI Application
+            description: Represents an instance of a EmberCSI application
 
 
   packages: |-


### PR DESCRIPTION
Add openshift-operator-lifecycle-manager to the OLM configmap
and rearrange owned CRDs keys like it written in other configmaps

Signed-off-by: Ido Rosenzwig <irosenzw@redhat.com>