### PR TITLE
Remove persistence config in Ceph example

### DIFF
--- a/deploy/examples/drivers/ceph.yaml
+++ b/deploy/examples/drivers/ceph.yaml
@@ -7,8 +7,6 @@ metadata:
 spec:
   config:
     envVars:
-      X_CSI_PERSISTENCE_CONFIG:
-        storage: crd
       X_CSI_EMBER_CONFIG:
         plugin_name: my-ceph
       X_CSI_BACKEND_CONFIG :


### PR DESCRIPTION
This will fall back to using a default CRD config if not set, so let's remove this.